### PR TITLE
Update publish.yml to use Trusted Publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,37 +4,70 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 jobs:
-  publish:
-    runs-on: ubuntu-22.04
+  build:
+    name: Build distribution
+    runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
 
-      - name: Build package
-        run: python -m build
+    - name: Build package
+      run: python -m build
 
-      - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
+    - name: Store distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-24.04
+    needs: build
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/frouros
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download distribution packages
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-24.04
+    needs: [build, publish-to-testpypi]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/frouros
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download distribution packages
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Update publish.yml workflow to use PyPI Trusted Publishers instead of API Tokens.

<!-- readthedocs-preview frouros start -->
----
📚 Documentation preview 📚: https://frouros--345.org.readthedocs.build/en/345/

<!-- readthedocs-preview frouros end -->