### PR TITLE
Add MMD unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         os: [
           ubuntu-22.04,
           windows-2022,
-          macos-12,
+          macos-14,
         ]
         python-version: [
           '3.9',

--- a/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
+++ b/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
@@ -3,6 +3,7 @@
 from functools import partial
 from typing import (
     Any,
+    Callable,
     Optional,
     Tuple,
 )
@@ -174,7 +175,7 @@ def test_mmd_chunk_size_equivalence(
         2,
     ],
 )
-def test_mmd_chunk_size_initialization_valid(
+def test_mmd_chunk_size_valid(
     chunk_size: Optional[int],
 ) -> None:
     """Test MMD initialization with valid chunk sizes.
@@ -229,4 +230,59 @@ def test_mmd_chunk_size_invalid(
         MMD(
             kernel=kernel,
             chunk_size=chunk_size,
+        )
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        partial(
+            rbf_kernel,
+            sigma=DEFAULT_SIGMA,
+        ),
+        lambda X, Y: X + Y,  # simple kernel
+    ],
+)
+def test_mmd_kernel_valid(
+    kernel: Callable,  # type: ignore
+) -> None:
+    """Test MMD initialization with valid kernels.
+
+    :param kernel: kernel to test
+    :type kernel: Callable
+    """
+    np.random.seed(seed=RANDOM_SEED)
+    X_ref = np.random.normal(0, 1, 100)
+    X_test = np.random.normal(0, 1, 100)
+
+    detector = MMD(
+        kernel=kernel,
+    )
+    _ = detector.fit(X=X_ref)
+    result = detector.compare(X=X_test)[0]
+
+    assert result is not None
+
+
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        None,
+        "invalid",
+        123,
+        [1, 2],
+        {1: 2},
+    ],
+)
+def test_mmd_kernel_invalid(
+    kernel: Any,
+) -> None:
+    """Test MMD initialization with invalid kernels.
+
+    :param kernel: kernel to test
+    :type kernel: Any
+    """
+    with pytest.raises((TypeError, ValueError)):
+        MMD(
+            kernel=kernel,
         )

--- a/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
+++ b/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
@@ -39,8 +39,8 @@ def test_mmd_batch_univariate(
     :type expected_distance: float
     """
     np.random.seed(seed=RANDOM_SEED)
-    X_ref = np.random.normal(*distribution_p)  # noqa: N806
-    X_test = np.random.normal(*distribution_q)  # noqa: N806
+    X_ref = np.random.normal(*distribution_p)
+    X_test = np.random.normal(*distribution_q)
 
     detector = MMD(
         kernel=partial(
@@ -84,8 +84,8 @@ def test_mmd_batch_precomputed_expected_k_xx(
     :type chunk_size: Optional[int]
     """
     np.random.seed(seed=RANDOM_SEED)
-    X_ref = np.random.normal(*distribution_p)  # noqa: N806
-    X_test = np.random.normal(*distribution_q)  # noqa: N806
+    X_ref = np.random.normal(*distribution_p)
+    X_test = np.random.normal(*distribution_q)
 
     kernel = partial(
         rbf_kernel,
@@ -102,7 +102,7 @@ def test_mmd_batch_precomputed_expected_k_xx(
     precomputed_distance = detector.compare(X=X_test)[0].distance
 
     # Computes mmd from scratch
-    scratch_distance = MMD._mmd(  # pylint: disable=protected-access
+    scratch_distance = MMD._mmd(
         X=X_ref,
         Y=X_test,
         kernel=kernel,
@@ -135,8 +135,8 @@ def test_mmd_chunk_size_equivalence(
     :type chunk_size: int
     """
     np.random.seed(seed=RANDOM_SEED)
-    X_ref = np.random.normal(*distribution_p)  # noqa: N806
-    X_test = np.random.normal(*distribution_q)  # noqa: N806
+    X_ref = np.random.normal(*distribution_p)
+    X_test = np.random.normal(*distribution_q)
 
     kernel = partial(
         rbf_kernel,

--- a/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
+++ b/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
@@ -1,7 +1,11 @@
 """Test MMD."""
 
 from functools import partial
-from typing import Any, Optional, Tuple
+from typing import (
+    Any,
+    Optional,
+    Tuple,
+)
 
 import numpy as np
 import pytest
@@ -182,7 +186,10 @@ def test_mmd_chunk_size_initialization_valid(
     X_ref = np.random.normal(0, 1, 100)
     X_test = np.random.normal(0, 1, 100)
 
-    kernel = partial(rbf_kernel, sigma=DEFAULT_SIGMA)
+    kernel = partial(
+        rbf_kernel,
+        sigma=DEFAULT_SIGMA,
+    )
 
     detector = MMD(
         kernel=kernel,
@@ -213,7 +220,10 @@ def test_mmd_chunk_size_invalid(
     :param chunk_size: chunk size to test
     :type chunk_size: Any
     """
-    kernel = partial(rbf_kernel, sigma=0.5)
+    kernel = partial(
+        rbf_kernel,
+        sigma=DEFAULT_SIGMA,
+    )
 
     with pytest.raises((TypeError, ValueError)):
         MMD(

--- a/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
+++ b/frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py
@@ -1,7 +1,7 @@
 """Test MMD."""
 
 from functools import partial
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import numpy as np
 import pytest
@@ -160,3 +160,63 @@ def test_mmd_chunk_size_equivalence(
     result_chunk = detector_chunk.compare(X=X_test)[0].distance
 
     assert np.isclose(result_none, result_chunk)
+
+
+@pytest.mark.parametrize(
+    "chunk_size",
+    [
+        None,
+        1,
+        2,
+    ],
+)
+def test_mmd_chunk_size_initialization_valid(
+    chunk_size: Optional[int],
+) -> None:
+    """Test MMD initialization with valid chunk sizes.
+
+    :param chunk_size: chunk size to test
+    :type chunk_size: Optional[int]
+    """
+    np.random.seed(seed=RANDOM_SEED)
+    X_ref = np.random.normal(0, 1, 100)
+    X_test = np.random.normal(0, 1, 100)
+
+    kernel = partial(rbf_kernel, sigma=DEFAULT_SIGMA)
+
+    detector = MMD(
+        kernel=kernel,
+        chunk_size=chunk_size,
+    )
+    _ = detector.fit(X=X_ref)
+    result = detector.compare(X=X_test)[0]
+
+    assert result is not None
+
+
+@pytest.mark.parametrize(
+    "chunk_size",
+    [
+        0,
+        -1,
+        "invalid",
+        1.5,
+        [1, 2],
+        {1: 2},
+    ],
+)
+def test_mmd_chunk_size_invalid(
+    chunk_size: Any,
+) -> None:
+    """Test MMD initialization with invalid chunk sizes.
+
+    :param chunk_size: chunk size to test
+    :type chunk_size: Any
+    """
+    kernel = partial(rbf_kernel, sigma=0.5)
+
+    with pytest.raises((TypeError, ValueError)):
+        MMD(
+            kernel=kernel,
+            chunk_size=chunk_size,
+        )


### PR DESCRIPTION
This pull request includes updates to the CI configuration and significant enhancements to the unit tests for the MMD data drift detector. The most important changes include updating the macOS version in the CI workflow and adding comprehensive tests for various chunk sizes and kernels in the `test_mmd.py` file.

CI Configuration Update:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL16-R16): Updated the macOS version from `macos-12` to `macos-14` to ensure compatibility with newer macOS environments.

Enhancements to Unit Tests:

* [`frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py`](diffhunk://#diff-3930e098b75c383e0be0c6b10275e5eec72e889531839e0cd00dfbcf0ca6f5c2L4-R19): Added constants `RANDOM_SEED` and `DEFAULT_SIGMA` for better maintainability and replaced hardcoded values with these constants in existing tests. [[1]](diffhunk://#diff-3930e098b75c383e0be0c6b10275e5eec72e889531839e0cd00dfbcf0ca6f5c2L4-R19) [[2]](diffhunk://#diff-3930e098b75c383e0be0c6b10275e5eec72e889531839e0cd00dfbcf0ca6f5c2L38-R54) [[3]](diffhunk://#diff-3930e098b75c383e0be0c6b10275e5eec72e889531839e0cd00dfbcf0ca6f5c2L80-R98)
* [`frouros/tests/unit/detectors/data_drift/batch/distance_based/test_mmd.py`](diffhunk://#diff-3930e098b75c383e0be0c6b10275e5eec72e889531839e0cd00dfbcf0ca6f5c2L96-R288): Introduced new tests to check the equivalence of MMD results with different chunk sizes and to verify the validity of chunk sizes and kernels.